### PR TITLE
Add registry settings for Windows Search and Firewall

### DIFF
--- a/Configurations/2009/PolicyRegSettings.json
+++ b/Configurations/2009/PolicyRegSettings.json
@@ -1,5 +1,19 @@
 [
     {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Search",
+        "RegItemValueName": "ConnectedSearchUseWeb",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "0",
+        "OptimizationState": "Apply"
+    }, 
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Search",
+        "RegItemValueName": "AllowCloudSearch",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "0",
+        "OptimizationState": "Apply"
+    },
+    {
         "RegItemPath": "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy",
         "RegItemValueName": "DeleteUserAppContainersOnLogoff",
         "RegItemValueType": "DWord",


### PR DESCRIPTION
Windows 11 Search may prompt you to verify your account, to access your own documents. These settings turn that 'feature' off.