### PR TITLE
Update OneDrive removal script to exclude WinSxS

### DIFF
--- a/Functions/Remove-WDOTRemoveOneDrive.ps1
+++ b/Functions/Remove-WDOTRemoveOneDrive.ps1
@@ -26,7 +26,7 @@ function Remove-WDOTRemoveOneDrive
         }
 
         Write-EventLog -EventId 80 -Message "Removing shortcut links for OneDrive" -LogName 'WDOT' -Source 'AdvancedOptimizations' -EntryType Information
-        Get-ChildItem 'C:\*' -Recurse -Force -EA SilentlyContinue -Include 'OneDrive', 'OneDrive.exe', 'OneDrive.ico' -Exclude 'C:\Windows\WinSxS' | Remove-Item -Force -Recurse -EA SilentlyContinue
+        Get-ChildItem 'C:\*' -Recurse -Force -EA SilentlyContinue -Include 'OneDrive', 'OneDrive.exe', 'OneDrive.ico' | Where-Object { $_.FullName -notlike '*\WinSxS\*' } | Remove-Item -Force -Recurse -EA SilentlyContinue
 
     }
     End


### PR DESCRIPTION
Also, be more specific about what actually does get deleted. This fix is because of an issue where if "OneDrive.svg" gets deleted, Windows 11 will fail the installation of the monthly CU, and the log shows it's because the .svg file is missing. This change now only attempts to remove OneDrive folder, OneDrive.ico, and OneDrive.exe. The fix for this has already been tested and confirmed by another project.