### PR TITLE
PSUseSingularNouns

### DIFF
--- a/Functions/Disable-WDOTAutoLoggers.ps1
+++ b/Functions/Disable-WDOTAutoLoggers.ps1
@@ -1,4 +1,4 @@
-﻿function Disable-WDOTAutoLoggers
+﻿function Disable-WDOTAutoLogger
 {
     [CmdletBinding()]
 

--- a/Functions/Disable-WDOTScheduledTasks.ps1
+++ b/Functions/Disable-WDOTScheduledTasks.ps1
@@ -1,4 +1,4 @@
-﻿function Disable-WDOTScheduledTasks
+﻿function Disable-WDOTScheduledTask
 {
     [CmdletBinding()]
 

--- a/Functions/Disable-WDOTServices.ps1
+++ b/Functions/Disable-WDOTServices.ps1
@@ -1,4 +1,4 @@
-﻿function Disable-WDOTServices
+﻿function Disable-WDOTService
 {
     [CmdletBinding()]
 

--- a/Functions/Optimize-WDOTDefaultUserSettings.ps1
+++ b/Functions/Optimize-WDOTDefaultUserSettings.ps1
@@ -1,4 +1,4 @@
-﻿function Optimize-WDOTDefaultUserSettings
+﻿function Optimize-WDOTDefaultUserSetting
 {
     [CmdletBinding()]
 

--- a/Functions/Optimize-WDOTEdgeSettings.ps1
+++ b/Functions/Optimize-WDOTEdgeSettings.ps1
@@ -1,4 +1,4 @@
-﻿function Optimize-WDOTEdgeSettings
+﻿function Optimize-WDOTEdgeSetting
 {
     [CmdletBinding()]
 

--- a/Functions/Optimize-WDOTLocalPolicySettings.ps1
+++ b/Functions/Optimize-WDOTLocalPolicySettings.ps1
@@ -1,4 +1,4 @@
-﻿function Optimize-WDOTLocalPolicySettings
+﻿function Optimize-WDOTLocalPolicySetting
 {
     [CmdletBinding()]
 

--- a/Functions/Optimize-WDOTNetworkOptimizations.ps1
+++ b/Functions/Optimize-WDOTNetworkOptimizations.ps1
@@ -1,4 +1,4 @@
-﻿function Optimize-WDOTNetworkOptimizations
+﻿function Optimize-WDOTNetworkOptimization
 {
     [CmdletBinding()]
 

--- a/Functions/Remove-WDOTAppxPackages.ps1
+++ b/Functions/Remove-WDOTAppxPackages.ps1
@@ -1,4 +1,4 @@
-﻿Function Remove-WDOTAppxPackages
+﻿Function Remove-WDOTAppxPackage
 {
     [CmdletBinding(SupportsShouldProcess)]
     Param

--- a/New-WVDConfigurationFiles.ps1
+++ b/New-WVDConfigurationFiles.ps1
@@ -19,9 +19,9 @@ Param (
     numbers, underscores, and hyphens.
 
 .EXAMPLE
-    New-WVDConfigurationFiles -FolderName <your config name>
-    Ex. New-WVDConfigurationFiles -FolderName "W11_24H2"
-    Ex. New-WVDConfigurationFiles -FolderName "WS25_24H2"
+    .\New-WVDConfigurationFiles.ps1 -FolderName <your config name>
+    Ex. .\New-WVDConfigurationFiles.ps1 -FolderName "W11_24H2"
+    Ex. .\New-WVDConfigurationFiles.ps1 -FolderName "WS25_24H2"
     Creates a new folder called <your config name> with all template files.
 
 .NOTES
@@ -29,7 +29,7 @@ Param (
     Version: 2.0
     Requires: PowerShell 5.1 or higher
 #>
-Function New-WVDConfigurationFiles {
+Function New-WVDConfigurationFile {
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([System.Boolean])]
     param (
@@ -88,7 +88,7 @@ Function New-WVDConfigurationFiles {
 
 # Main execution
 if (-not $PSBoundParameters.ContainsKey('WhatIf') -and -not $PSBoundParameters.ContainsKey('Confirm')) {
-    $result = New-WVDConfigurationFiles -FolderName $FolderName
+    $result = New-WVDConfigurationFile -FolderName $FolderName
     if ($result) {
         Write-Host "Configuration folder '$FolderName' created successfully!" -ForegroundColor Green
     } else {

--- a/Set-WVDConfigurations.ps1
+++ b/Set-WVDConfigurations.ps1
@@ -47,11 +47,11 @@ Param (
     If specified, creates a backup of the original file before making changes.
 
 .EXAMPLE
-    Set-WVDConfigurations -ConfigurationFile "AppxPackages" -ConfigFolderName "Production"
+    .\Set-WVDConfigurations.ps1 -ConfigurationFile "AppxPackages" -ConfigFolderName "Production"
     Interactively configure AppxPackages optimizations for the Production folder.
 
 .EXAMPLE
-    Set-WVDConfigurations -ConfigurationFile "Services.json" -ConfigFolderName "Test1" -ApplyAll
+    .\Set-WVDConfigurations.ps1 -ConfigurationFile "Services.json" -ConfigFolderName "Test1" -ApplyAll
     Apply all Services optimizations for the Test1 folder without prompting.
 
 .NOTES
@@ -59,7 +59,7 @@ Param (
     Version: 2.0
     Requires: PowerShell 5.1 or higher
 #>
-Function Set-WVDConfigurations
+Function Set-WVDConfiguration
 {
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([System.Boolean])]
@@ -339,7 +339,7 @@ if (-not $PSBoundParameters.ContainsKey('WhatIf') -and -not $PSBoundParameters.C
     if ($SkipAll) { $params.SkipAll = $true }
     if ($CreateBackup) { $params.CreateBackup = $true }
 
-    $result = Set-WVDConfigurations @params
+    $result = Set-WVDConfiguration @params
 
     if ($result)
     {

--- a/Windows_Optimization.ps1
+++ b/Windows_Optimization.ps1
@@ -261,7 +261,7 @@ PROCESS {
     #region APPX Packages
     If ($Optimizations -contains "AppxPackages" -or $Optimizations -contains "All")
     {
-        Remove-WDOTAppxPackages
+        Remove-WDOTAppxPackage
     }
     #endregion
 
@@ -270,7 +270,7 @@ PROCESS {
     # change its "VDIState" from Disabled to Enabled, or remove it from the json completely.
     If ($Optimizations -contains 'ScheduledTasks' -or $Optimizations -contains "All")
     {
-        Disable-WDOTScheduledTasks
+        Disable-WDOTScheduledTask
     }
     #endregion
 
@@ -278,21 +278,21 @@ PROCESS {
     # Apply appearance customizations to default user registry hive, then close hive file
     If ($Optimizations -contains "DefaultUserSettings" -or $Optimizations -contains "All")
     {
-        Optimize-WDOTDefaultUserSettings
+        Optimize-WDOTDefaultUserSetting
     }
     #endregion
 
     #region Disable Windows Traces
     If ($Optimizations -contains "AutoLoggers" -or $Optimizations -contains "All")
     {
-        Disable-WDOTAutoLoggers
+        Disable-WDOTAutoLogger
     }
     #endregion
 
     #region Disable Services
     If ($Optimizations -contains "Services" -or $Optimizations -contains "All")
     {
-        Disable-WDOTServices
+        Disable-WDOTService
     }
     #endregion
 
@@ -300,7 +300,7 @@ PROCESS {
     # LanManWorkstation optimizations
     If ($Optimizations -contains "NetworkOptimizations" -or $Optimizations -contains "All")
     {
-        Optimize-WDOTNetworkOptimizations
+        Optimize-WDOTNetworkOptimization
     }
     #endregion
 
@@ -312,14 +312,14 @@ PROCESS {
     #   * set the "Select when Quality Updates are received" policy
     If ($Optimizations -contains "LocalPolicy" -or $Optimizations -contains "All")
     {
-        Optimize-WDOTLocalPolicySettings
+        Optimize-WDOTLocalPolicySetting
     }
     #endregion
 
     #region Edge Settings
     If ($AdvancedOptimizations -contains "Edge" -or $AdvancedOptimizations -contains "All")
     {
-        Optimize-WDOTEdgeSettings
+        Optimize-WDOTEdgeSetting
     }
     #endregion
 


### PR DESCRIPTION
Hello,
May I propose that the code follows coding best practices using the PSScriptAnalyzer module?
Here's the fix of PSUseSingularNouns issue in all current files.
The examples in the help block have been modified to make explicit the invocation of the New-WVDConfigurationFiles.ps1 script. The script/file name can still be plural and but not the functions in the script.