### PR TITLE
Specify WDOT LogName for event log commands

### DIFF
--- a/Windows_Optimization.ps1
+++ b/Windows_Optimization.ps1
@@ -151,13 +151,13 @@ Begin
     If (-not([System.Diagnostics.EventLog]::SourceExists('WDOT')))
     {
         # All WDOT main function Event ID's [1-9]
-        New-EventLog -Source $EventSources @EVT @HT
-        Limit-EventLog -OverflowAction OverWriteAsNeeded -MaximumSize 64KB @EVT @HT
-        Write-EventLog @EVT  -EntryType Information -EventId 1 -Message "Log Created" @sHT
+        New-EventLog -LogName 'WDOT' -Source $EventSources @HT
+        Limit-EventLog -LogName 'WDOT' -OverflowAction OverWriteAsNeeded -MaximumSize 64KB @HT
+        Write-EventLog @EVT -EntryType Information -EventId 1 -Message "Log Created" @sHT
     }
     Else
     {
-        New-EventLog -Source $EventSources @EVT @sHT
+        New-EventLog -LogName 'WDOT' -Source $EventSources @sHT
     }
 
     # Handle parameter set and validate configuration path


### PR DESCRIPTION
Use an explicit -LogName 'WDOT' when creating and limiting the event log to ensure the event source is associated with the correct log. Adjusted New-EventLog and Limit-EventLog calls to include -LogName and updated the New-EventLog call in the existing-else branch for consistency; minor Write-EventLog parameter ordering/splat alignment for clarity.