### PR TITLE
Use NormalizedFileName when building config path

### DIFF
--- a/Set-WVDConfigurations.ps1
+++ b/Set-WVDConfigurations.ps1
@@ -110,10 +110,7 @@ Function Set-WVDConfiguration
         {
             # Normalize configuration file name
             $ConfigFileBaseName = [System.IO.Path]::GetFileNameWithoutExtension($ConfigurationFile)
-            if (-not $ConfigurationFile.EndsWith('.json'))
-            {
-                $ConfigurationFile = "$ConfigFileBaseName.json"
-            }
+            $NormalizedFileName = if ($ConfigurationFile.EndsWith('.json')) { $ConfigurationFile } else { "$ConfigFileBaseName.json" }
 
             # Validate configuration file type (case-insensitive lookup)
             $ConfigMapping = $null
@@ -135,7 +132,7 @@ Function Set-WVDConfiguration
             # Build target file path
             $ConfigurationsRoot = Join-Path -Path $PSScriptRoot -ChildPath 'Configurations'
             $ConfigFolder = Join-Path -Path $ConfigurationsRoot -ChildPath $ConfigFolderName
-            $TargetFile = Join-Path -Path $ConfigFolder -ChildPath $ConfigurationFile
+            $TargetFile = Join-Path -Path $ConfigFolder -ChildPath $NormalizedFileName
 
             # Validate paths exist
             if (-not (Test-Path -Path $ConfigFolder -PathType Container))


### PR DESCRIPTION
PowerShell 5.1 re-validates constrained parameter variables on reassignment, throwing the obscure "cannot be validated" error even though [ValidateNotNullOrEmpty()] is the only attribute. Avoid mutating $ConfigurationFile by introducing $NormalizedFileName that guarantees a .json extension (using an inline if). Use $NormalizedFileName when constructing $TargetFile, simplifying the previous conditional block and preventing side effects on the original parameter.